### PR TITLE
Allow Insecure Request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,12 +69,17 @@ There are two things you need to do in ``settings.py``
    ``AUTOCREATE_VALID_SSL_USERS = True``. Auto-created users will be set to
    inactive by default, consider using the `User.is_active`_ field in your
    `LOGIN_REDIRECT_URL`_ view to notifying the user of their status.
-3. If you want to use the standard login url, set `SSLCLIENT_LOGIN_URL = None` or leave it undefined.
+   
+For details, see ``testapp/ssltest/settings.py``
+   
+Optional Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+1. If you want to use the standard login url, set `SSLCLIENT_LOGIN_URL = None` or leave it undefined.
    For cases where you want a seperate login URL for SSL auth, set `SSLCLIENT_LOGIN_URL = "/YOUR_URL/"`.
    `SSLCLIENT_LOGIN_URL` is designed for use cases where some users login via the regular Django login
    without using SSLCLIENT auth, but you have a seperate login URL for users that login with SSLCLIENT auth.
-
-For details, see ``testapp/ssltest/settings.py``
+2. If you want to allow insecure request (eg. your django app is behind a proxy or load balancer) set
+   `SSLCLIENT_ALLOW_INSECURE_REQUEST = True`. If not set, secure connection will be required by default.
 
 Smart Card support
 ~~~~~~~~~~~~~~~~~~

--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -58,12 +58,10 @@ class SSLClientAuthBackend(backends.ModelBackend):
         _module = import_module(_module_name)  # We need a non-empty fromlist
         USER_DATA_FN = getattr(_module, _function_name)  # NOQA: N806
 
-        if ((not hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST")) or
-                (hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST") and
-                    settings.SSLCLIENT_ALLOW_INSECURE_REQUEST is False)):
-            if not request.is_secure():
-                logger.debug("insecure request")
-                return None
+        allow_insecure_request = getattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST", False)
+        if not allow_insecure_request and not request.is_secure():
+            logger.debug("insecure request")
+            return None
         authentication_status = request.META.get('HTTP_X_SSL_AUTHENTICATED', None)
         if (authentication_status != "SUCCESS" or 'HTTP_X_SSL_USER_DN' not in request.META):
             logger.warn(

--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -58,8 +58,9 @@ class SSLClientAuthBackend(backends.ModelBackend):
         _module = import_module(_module_name)  # We need a non-empty fromlist
         USER_DATA_FN = getattr(_module, _function_name)  # NOQA: N806
 
-        if ((not hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST")) or \
-            (hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST") and settings.SSLCLIENT_ALLOW_INSECURE_REQUEST == False)):
+        if ((not hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST")) or
+                (hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST") and
+                    settings.SSLCLIENT_ALLOW_INSECURE_REQUEST is False)):
             if not request.is_secure():
                 logger.debug("insecure request")
                 return None

--- a/django_ssl_auth/base.py
+++ b/django_ssl_auth/base.py
@@ -58,9 +58,11 @@ class SSLClientAuthBackend(backends.ModelBackend):
         _module = import_module(_module_name)  # We need a non-empty fromlist
         USER_DATA_FN = getattr(_module, _function_name)  # NOQA: N806
 
-        if not request.is_secure():
-            logger.debug("insecure request")
-            return None
+        if ((not hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST")) or \
+            (hasattr(settings, "SSLCLIENT_ALLOW_INSECURE_REQUEST") and settings.SSLCLIENT_ALLOW_INSECURE_REQUEST == False)):
+            if not request.is_secure():
+                logger.debug("insecure request")
+                return None
         authentication_status = request.META.get('HTTP_X_SSL_AUTHENTICATED', None)
         if (authentication_status != "SUCCESS" or 'HTTP_X_SSL_USER_DN' not in request.META):
             logger.warn(

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -38,3 +38,32 @@ class Tests(TestCase):
             self.assertEqual(user.username, '42')
             self.assertEqual(user.first_name, 'John')
             self.assertEqual(user.last_name, 'Smith')
+
+    def test_login_new_user_insecure(self):
+        """Ensure users are automatically created."""
+        # Simulate an SSL connection (of a new user)
+        with self.settings(SSLCLIENT_ALLOW_INSECURE_REQUEST=True):
+            result = self.client.get(
+                settings.LOGIN_URL,
+                HTTP_X_SSL_AUTHENTICATED='SUCCESS',
+                HTTP_X_SSL_USER_DN='C=FI/serialNumber=42/GN=John/SN=Smith/CN=John Smith',
+                HTTP_X_FORWARDED_PROTOCOL='http'
+            )
+
+        # Ensure the new user was created
+        user = User.objects.last()
+        self.assertEqual(user.username, '42')
+        self.assertEqual(user.first_name, 'John')
+        self.assertEqual(user.last_name, 'Smith')
+
+    def test_login_new_user_insecure_fail(self):
+        """Ensure users are automatically created."""
+        # Simulate an SSL connection (of a new user)
+        with self.settings(SSLCLIENT_ALLOW_INSECURE_REQUEST=False):
+            result = self.client.get(
+                settings.LOGIN_URL,
+                HTTP_X_SSL_AUTHENTICATED='SUCCESS',
+                HTTP_X_SSL_USER_DN='C=FI/serialNumber=42/GN=John/SN=Smith/CN=John Smith',
+                HTTP_X_FORWARDED_PROTOCOL='http'
+            )
+            self.assertEqual(result.status_code, 404)

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -43,7 +43,7 @@ class Tests(TestCase):
         """Ensure users are automatically created."""
         # Simulate an SSL connection (of a new user)
         with self.settings(SSLCLIENT_ALLOW_INSECURE_REQUEST=True):
-            result = self.client.get(
+            self.client.get(
                 settings.LOGIN_URL,
                 HTTP_X_SSL_AUTHENTICATED='SUCCESS',
                 HTTP_X_SSL_USER_DN='C=FI/serialNumber=42/GN=John/SN=Smith/CN=John Smith',


### PR DESCRIPTION
This setting allows insecure requests. This is useful for local development or in cases where ssl is handled by a proxy external to the django app/container. 